### PR TITLE
Add cancel callback button and cancel confirmation pages

### DIFF
--- a/callmeback/frontend/src/Routes.jsx
+++ b/callmeback/frontend/src/Routes.jsx
@@ -3,6 +3,8 @@ import { Route, Switch, BrowserRouter as Router } from 'react-router-dom'
 import Home from './components/Home.jsx'
 import Reservation from './components/Reservation.jsx'
 import ThankYou from './components/ThankYou.jsx'
+import Cancel from './components/Cancel.jsx'
+import CancelConfirmation from './components/CancelConfirmation.jsx'
 
 function Routes() {
     return (
@@ -11,6 +13,8 @@ function Routes() {
                 <Switch>
                     <Route path='/home' component={Home} />
                     <Route path='/thankyou' component={ThankYou} />
+                    <Route path='/cancel' component={Cancel} />
+                    <Route path='/cancelconfirmation' component={CancelConfirmation} />
                     <Route path='/reservations/:id' component={Reservation} />
                     <Route exact path='/' component={Home} />
                 </Switch>

--- a/callmeback/frontend/src/components/Cancel.jsx
+++ b/callmeback/frontend/src/components/Cancel.jsx
@@ -20,7 +20,10 @@ function Cancel() {
             <div style={{"fontSize":"small"}}>If you cancel, we will not call you. You can always schedule a new call later.</div>
             <br/>
             <div style={{"textAlign":"center"}}>
-            <Button size="small"><Link to="/cancelconfirmation">Cancel my call</Link></Button>
+            <Button size="small">
+                {/*TODO: Send cancelation to the backend.*/}
+                <Link to="/cancelconfirmation">Cancel my call</Link>
+            </Button>
             <br/>
             <br/>
             <Link to={reservationLink} style={{"fontSize":"small"}}>Keep my call</Link>

--- a/callmeback/frontend/src/components/Cancel.jsx
+++ b/callmeback/frontend/src/components/Cancel.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Container, Button } from 'semantic-ui-react'
+import Moment from 'react-moment';
+import { useLocation } from "react-router";
+import { Link } from 'react-router-dom';
+
+function Cancel() {
+    let location = useLocation();
+
+    const callStartFormatted = <Moment format="h:mm A">{location.state.expCallStartMin}</Moment>
+    const callStartMaxFormatted = <Moment format="h:mm A">{location.state.expCallStartMax}</Moment>
+    const reservationLink = "/reservations/" + location.state.id
+
+    return (
+        <Container text className='paper'>
+            <div style={{"textAlign":"center"}}>Cancel your call?</div>
+            <br/>
+            <div style={{"fontSize":"small"}}>You have a call with us scheduled to start between {callStartFormatted} and {callStartMaxFormatted} today.</div>
+            <br/>
+            <div style={{"fontSize":"small"}}>If you cancel, we will not call you. You can always schedule a new call later.</div>
+            <br/>
+            <div style={{"textAlign":"center"}}>
+            <Button size="small"><Link to="/cancelconfirmation">Cancel my call</Link></Button>
+            <br/>
+            <br/>
+            <Link to={reservationLink} style={{"fontSize":"small"}}>Keep my call</Link>
+            </div>
+        </Container>
+    )
+}
+
+export default Cancel;

--- a/callmeback/frontend/src/components/CancelConfirmation.jsx
+++ b/callmeback/frontend/src/components/CancelConfirmation.jsx
@@ -4,7 +4,7 @@ import { Container } from 'semantic-ui-react'
 function CancelConfirmation() {
     return (
         <Container text className='paper'>
-            <div>You have cancelled your call with us. We're here if you want to <a href="/home">Request a new call.</a></div>
+            <div>You have canceled your call with us. We're here if you want to <a href="/home">Request a new call.</a></div>
         </Container>
     )
 }

--- a/callmeback/frontend/src/components/CancelConfirmation.jsx
+++ b/callmeback/frontend/src/components/CancelConfirmation.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Container } from 'semantic-ui-react'
+
+function CancelConfirmation() {
+    return (
+        <Container text className='paper'>
+            <div>You have cancelled your call with us. We're here if you want to <a href="/home">Request a new call.</a></div>
+        </Container>
+    )
+}
+
+export default CancelConfirmation;

--- a/callmeback/frontend/src/components/Reservation.jsx
+++ b/callmeback/frontend/src/components/Reservation.jsx
@@ -3,7 +3,6 @@ import {useParams} from 'react-router';
 import { Container } from 'semantic-ui-react'
 import Feedback from './Feedback.jsx'
 import WaitDetails from './WaitDetails.jsx'
-import moment from 'moment';
 
 function Reservation() {
     const { id } = useParams();
@@ -33,7 +32,7 @@ function Reservation() {
 
         hasBeenDisplayed = true;
     
-        return {topic, status, waitMin, waitMax, expCallStartMin, expCallStartMax}
+        return {topic, status, waitMin, waitMax, expCallStartMin, expCallStartMax, id}
     }
 
     const [reservationDetails, setReservationDetails] = useState(() => {

--- a/callmeback/frontend/src/components/WaitDetails.jsx
+++ b/callmeback/frontend/src/components/WaitDetails.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
 
 function WaitDetails(props) {
-    const {topic, expCallStartMin, expCallStartMax, waitMin, waitMax} = props.reservationDetails
+    const {topic, expCallStartMin, expCallStartMax, waitMin, waitMax, id} = props.reservationDetails
 
     const callStartFormatted = <Moment format="h:mm A">{expCallStartMin}</Moment>
     const callStartMaxFormatted = <Moment format="h:mm A">{expCallStartMax}</Moment>
@@ -25,6 +25,7 @@ function WaitDetails(props) {
                             state: {
                                 expCallStartMin: expCallStartMin,
                                 expCallStartMax: expCallStartMax,
+                                id: id,
                             }
                         }}
                         style={{"fontSize":"12px"}}

--- a/callmeback/frontend/src/components/WaitDetails.jsx
+++ b/callmeback/frontend/src/components/WaitDetails.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Container, Icon } from 'semantic-ui-react'
+import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
 
 function WaitDetails(props) {
@@ -7,7 +8,7 @@ function WaitDetails(props) {
 
     const callStartFormatted = <Moment format="h:mm A">{expCallStartMin}</Moment>
     const callStartMaxFormatted = <Moment format="h:mm A">{expCallStartMax}</Moment>
-
+    
     return (
         <Container text className='paper'>
             <div>
@@ -18,6 +19,18 @@ function WaitDetails(props) {
                     <div style={{"fontSize":"30px"}}>
                         <Icon name='clock' />  {waitMin} - {waitMax} min
                     </div>
+                    <Link
+                        to={{
+                            pathname: "/cancel",
+                            state: {
+                                expCallStartMin: expCallStartMin,
+                                expCallStartMax: expCallStartMax,
+                            }
+                        }}
+                        style={{"fontSize":"12px"}}
+                    >
+                        Cancel call back
+                    </Link>
                 </div>
                 <br/>
                 <p style={{"textAlign":"left", "fontSize":"small"}}>


### PR DESCRIPTION
Fixes #23 

Adds cancel callback button to WaitDetails page, and sends to a cancel confirmation page, and then a "you successfully cancelled" page.

Cancel your call button: https://user-images.githubusercontent.com/29430896/80823219-45cd3900-8baa-11ea-9846-bce4f097af65.png
Cancel your call confirmation: https://user-images.githubusercontent.com/29430896/80823236-4a91ed00-8baa-11ea-808a-632de92ced87.png
Cancellation completion page: https://user-images.githubusercontent.com/29430896/80823233-4960c000-8baa-11ea-95f2-8ecb9c724a4f.png

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR