### PR TITLE
Add live update functionality to `./gradlew start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To build and run:
 
 * `./gradlew appName:buildImage` - Builds an image for a local run
 * `./gradlew appName:buildProdImage` - Builds a hermetic prod image
-* `./gradlew appName:start` - Starts the app locally
+* `./gradlew appName:start` - Starts (or updates) the running app
 * `./gradlew appName:stop` - Stops the running app
 
 Replace `appName` with the directory name you'd like to run or exclude it to

--- a/callmeback/build.gradle
+++ b/callmeback/build.gradle
@@ -127,6 +127,20 @@ task applyChanges(type: Exec) {
     .withPropertyName('sourceFiles')
     .withPathSensitivity(PathSensitivity.RELATIVE)
   commandLine 'kubectl', 'apply', '-k', 'kubernetes'
+
+  // Kubernetes does not update the images of running pods even if the image is
+  // updated. The way we can do that is by forcing a scale operation.
+  //
+  // H/T to pagid on StackOverflow for the suggestion
+  // https://stackoverflow.com/questions/41735829/update-a-deployment-image-in-kubernetes
+  doLast {
+    exec {
+      commandLine 'kubectl', 'scale', '--replicas=0', '--all', 'deployments'
+    }
+    exec {
+      commandLine 'kubectl', 'scale', '--replicas=1', '--all', 'deployments'
+    }
+  }
 }
 
 task start(type: Exec) {

--- a/helloworld/build.gradle
+++ b/helloworld/build.gradle
@@ -127,6 +127,20 @@ task applyChanges(type: Exec) {
     .withPropertyName('sourceFiles')
     .withPathSensitivity(PathSensitivity.RELATIVE)
   commandLine 'kubectl', 'apply', '-k', 'kubernetes'
+
+  // Kubernetes does not update the images of running pods even if the image is
+  // updated. The way we can do that is by forcing a scale operation.
+  //
+  // H/T to pagid on StackOverflow for the suggestion
+  // https://stackoverflow.com/questions/41735829/update-a-deployment-image-in-kubernetes
+  doLast {
+    exec {
+      commandLine 'kubectl', 'scale', '--replicas=0', '--all', 'deployments'
+    }
+    exec {
+      commandLine 'kubectl', 'scale', '--replicas=1', '--all', 'deployments'
+    }
+  }
 }
 
 task start(type: Exec) {


### PR DESCRIPTION
Fixes #56. Now subsequent `./gradlew start` operations will update the image.

_Based on PR #60_

- [x] Tests pass
- [x] Appropriate changes to README are included in PR