### PR TITLE
Fix styling error upon refresh

### DIFF
--- a/callmeback/frontend/public/index.html
+++ b/callmeback/frontend/public/index.html
@@ -26,7 +26,7 @@
   </head>
   <body>
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css" />
-    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="/style.css" />
     <div id="root"></div>
     <!--
       This HTML file is a template.


### PR DESCRIPTION
Fix styling error upon refresh. The underlying issue was that index.html was including "./styles.css" instead of "/styles.css". Upon refresh on a route (such as /reservations/{id}), it was looking for styles.css in the route directory (such as /reservations/styles.css), not the root directory.

Fix #75