### PR TITLE
Use times returned from backend rather than hardcoded ones on frontend

### DIFF
--- a/callmeback/frontend/src/components/Reservation.jsx
+++ b/callmeback/frontend/src/components/Reservation.jsx
@@ -11,26 +11,25 @@ function Reservation() {
     const [reservationDetails, setReservationDetails] = useState({});
 
     const fetchReservation = async () => {
-        // This will be replaced with the callback interval from API call.
-        const now = new Date();
-        const expCallStartMin = new Date(now.getTime() + 10*60000)
-        const expCallStartMax = new Date(expCallStartMin.getTime() + 5*60000)
-
-        // Calculations for wait time given the min and max exp call time.
-        const waitMinMS = expCallStartMin - now;
-        const waitMaxMS = expCallStartMax - now;
-        const waitMin = Math.round(((waitMinMS % 86400000) % 3600000) / 60000); // minutes
-        const waitMax = Math.round(((waitMaxMS % 86400000) % 3600000) / 60000); 
-
         try {
             const response = await axios.get("/api/v1/reservations/" + id); //concatenate id variable
             console.log(response.data)
+    
+            const now = new Date();
+            const expCallStartMin = new Date(response.data.window.min)
+            const expCallStartMax = new Date(response.data.window.max)
+    
+            // Calculations for wait time given the min and max exp call time.
+            const waitMinMS = expCallStartMin - now;
+            const waitMaxMS = expCallStartMax - now;
+            const waitMin = Math.round(((waitMinMS % 86400000) % 3600000) / 60000); // minutes
+            const waitMax = Math.round(((waitMaxMS % 86400000) % 3600000) / 60000); 
     
             setReservationDetails({
                 id: id,
                 topic: "Employment", // Not in response yet
                 resolved: response.data.resolution != null,
-                waitMin, waitMax, expCallStartMin, expCallStartMax, // Not in response yet
+                waitMin, waitMax, expCallStartMin, expCallStartMax,
             });
         }
         catch (error) {


### PR DESCRIPTION
Fixes #72 

Uses the min and max wait time returned from the backend rather than hardcoding them on the frontend. Currently the min and max interval does not get shorter over time, it will always be 10-30 min, which will be used to determine the expected call times. The exp call times won't change over time, so the exp wait time will get shorter each minute (9-29 min after a min, 8-28 after two mins, etc).

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR