### PR TITLE
Fix a few warnings that appear with npm start

### DIFF
--- a/callmeback/frontend/src/components/Feedback.jsx
+++ b/callmeback/frontend/src/components/Feedback.jsx
@@ -12,7 +12,7 @@ function Feedback(props) {
     const history = useHistory();
 
     useEffect(() => {
-        if (rating != defaultRating) {
+        if (rating !== defaultRating) {
           // only enable submit button if the rating has been set.
           if (!submitButtonEnabled) setSubmitButtonEnabled(true);
         } else {

--- a/callmeback/frontend/src/components/Reservation.jsx
+++ b/callmeback/frontend/src/components/Reservation.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useCallback} from 'react';
 import {useParams} from 'react-router';
 import { Container } from 'semantic-ui-react'
 import Feedback from './Feedback.jsx'
@@ -10,7 +10,7 @@ function Reservation() {
 
     const [reservationDetails, setReservationDetails] = useState({});
 
-    const fetchReservation = async () => {
+    const fetchReservation = useCallback(async () => {
         // This will be replaced with the callback interval from API call.
         const now = new Date();
         const expCallStartMin = new Date(now.getTime() + 10*60000)
@@ -36,7 +36,7 @@ function Reservation() {
         catch (error) {
             console.log(error); // Add other error handling.
         }
-    }
+    }, [id])
 
     useEffect(() => {
         fetchReservation(); // Run this once upfront to get the data.
@@ -46,7 +46,7 @@ function Reservation() {
             fetchReservation();
         }, 1000 * 10);
         return () => clearInterval(interval);
-    }, [])
+    }, [fetchReservation])
 
     return (
         <Container text textAlign='center' className='paper'>
@@ -55,7 +55,7 @@ function Reservation() {
             <WaitDetails reservationDetails={reservationDetails}/>}
             {reservationDetails.id !== "" &&
             reservationDetails.resolved &&
-            <Feedback id={id}/>}
+            <Feedback id={reservationDetails.id}/>}
         </Container>
     )
 }


### PR DESCRIPTION
Fix warnings about using != instead of !== and having a useEffect with a missing dependency. For the latter, followed guidance here: https://stackoverflow.com/questions/55840294/how-to-fix-missing-dependency-warning-when-using-useeffect-react-hook

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR