### PR TITLE
Pass "reservation" from home page (on form submission) to the Reservations page

### DIFF
--- a/callmeback/frontend/src/components/Home.jsx
+++ b/callmeback/frontend/src/components/Home.jsx
@@ -38,10 +38,7 @@ function Home(props) {
       // /reservations/{id} where they will see information about callback.
       let hrefArray = response.data._links.self.href.split('/');
       let reservationId = hrefArray[hrefArray.length - 1];
-      history.push({
-        pathName: '/reservations/' + reservationId,
-        state: { reservation: response.data },
-      });
+      history.push('/reservations/' + reservationId, { reservation: response.data });
     }, (error) => {
       console.log(error);
       // TODO Display error in the UI.

--- a/callmeback/frontend/src/components/Home.jsx
+++ b/callmeback/frontend/src/components/Home.jsx
@@ -38,7 +38,10 @@ function Home(props) {
       // /reservations/{id} where they will see information about callback.
       let hrefArray = response.data._links.self.href.split('/');
       let reservationId = hrefArray[hrefArray.length - 1];
-      history.push('/reservations/' + reservationId);
+      history.push({
+        pathName: '/reservations/' + reservationId,
+        state: { reservation: response.data },
+      });
     }, (error) => {
       console.log(error);
       // TODO Display error in the UI.

--- a/callmeback/frontend/src/components/Reservation.jsx
+++ b/callmeback/frontend/src/components/Reservation.jsx
@@ -5,10 +5,15 @@ import Feedback from './Feedback.jsx'
 import WaitDetails from './WaitDetails.jsx'
 import axios from 'axios';
 
-function Reservation() {
+function Reservation(props) {
     const { id } = useParams();
 
-    const [reservationDetails, setReservationDetails] = useState({});
+    const [reservationDetails, setReservationDetails] = useState(() => {
+        if (!!props && !!props.location.state) {
+            console.log(props.location.state.reservation)
+        }
+        return {}
+    });
 
     const fetchReservation = async () => {
         // This will be replaced with the callback interval from API call.

--- a/callmeback/frontend/src/components/Reservation.jsx
+++ b/callmeback/frontend/src/components/Reservation.jsx
@@ -7,35 +7,38 @@ import axios from 'axios';
 
 function Reservation(props) {
     const { id } = useParams();
+    const now = new Date();
+
+    const convertReservationToState = (reservation) => {
+        const expCallStartMin = new Date(reservation.window.min)
+        const expCallStartMax = new Date(reservation.window.max)
+
+        // Calculations for wait time given the min and max exp call time.
+        const waitMinMS = expCallStartMin - now;
+        const waitMaxMS = expCallStartMax - now;
+        const waitMin = Math.round(((waitMinMS % 86400000) % 3600000) / 60000); // minutes
+        const waitMax = Math.round(((waitMaxMS % 86400000) % 3600000) / 60000); 
+
+        return {
+            id: id,
+            topic: "Employment", // Not in response yet
+            resolved: reservation.resolution != null,
+            waitMin, waitMax, expCallStartMin, expCallStartMax,
+        };
+    }
 
     const [reservationDetails, setReservationDetails] = useState(() => {
         if (!!props && !!props.location.state) {
-            console.log(props.location.state.reservation)
+            return convertReservationToState(props.location.state.reservation)
         }
         return {}
     });
 
     const fetchReservation = async () => {
         try {
-            const response = await axios.get("/api/v1/reservations/" + id); //concatenate id variable
-            console.log(response.data)
-    
-            const now = new Date();
-            const expCallStartMin = new Date(response.data.window.min)
-            const expCallStartMax = new Date(response.data.window.max)
-    
-            // Calculations for wait time given the min and max exp call time.
-            const waitMinMS = expCallStartMin - now;
-            const waitMaxMS = expCallStartMax - now;
-            const waitMin = Math.round(((waitMinMS % 86400000) % 3600000) / 60000); // minutes
-            const waitMax = Math.round(((waitMaxMS % 86400000) % 3600000) / 60000); 
-    
-            setReservationDetails({
-                id: id,
-                topic: "Employment", // Not in response yet
-                resolved: response.data.resolution != null,
-                waitMin, waitMax, expCallStartMin, expCallStartMax,
-            });
+            const response = await axios.get("/api/v1/reservations/" + id);
+            const reservation = convertReservationToState(response.data);
+            setReservationDetails(reservation);
         }
         catch (error) {
             console.log(error); // Add other error handling.


### PR DESCRIPTION
The reservation is returned from the POST request made on form submission (when a call back is requested) - we can pass this information to the Reservations page so that it can immediately render rather than waiting for the GET call to the API to get the reservation from its id.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR