### PR TITLE
Prevent wait details from rendering before the necessary wait time data has been passed

### DIFF
--- a/callmeback/frontend/src/components/WaitDetails.jsx
+++ b/callmeback/frontend/src/components/WaitDetails.jsx
@@ -13,7 +13,7 @@ function WaitDetails(props) {
     
     return (
         <Container text className='paper'>
-            <div>
+            {!!waitMin && <div>
                 <div style={{"textAlign":"center"}} >
                     <div style={{"fontSize":"20px"}}>
                         We'll call you back in
@@ -49,7 +49,7 @@ function WaitDetails(props) {
                     <label style={{"display":"table-cell"}}>Text me five minutes before as a reminder. <a>Data charges</a> may apply.</label>              
                     </div>
                 </p>
-            </div>
+            </div>}
         </Container>
     )
 


### PR DESCRIPTION
Without this fix, the wait time values would for a millisecond be rendered even if they were not yet calculated, before getting updated. Prevent this behavior

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR