### PR TITLE
Remove 'back' from all phrases with 'call back'

### DIFF
--- a/callmeback/frontend/src/components/Home.jsx
+++ b/callmeback/frontend/src/components/Home.jsx
@@ -35,7 +35,7 @@ function Home(props) {
       console.log(response);
 
       // Get ID of reservation from response, and direct the user to
-      // /reservations/{id} where they will see information about callback.
+      // /reservations/{id} where they will see information about their call.
       let hrefArray = response.data._links.self.href.split('/');
       let reservationId = hrefArray[hrefArray.length - 1];
       history.push('/reservations/' + reservationId, { reservation: response.data });
@@ -50,7 +50,7 @@ function Home(props) {
       <div >
         <Header as="h1">Request a call with us</Header>
         <div>
-          Tell us what you need and someone from our New York State offices will call you back.
+          Tell us what you need and someone from our New York State offices will call you.
         </div>
         <br/>
         <Form onSubmit={handleSubmit}>

--- a/callmeback/frontend/src/components/WaitDetails.jsx
+++ b/callmeback/frontend/src/components/WaitDetails.jsx
@@ -17,7 +17,7 @@ function WaitDetails(props) {
             <div>
                 <div style={{"textAlign":"center"}} >
                     <div style={{"fontSize":"20px"}}>
-                        We'll call you back in
+                        We'll call you in
                     </div>
                     <div style={{"fontSize":"30px"}}>
                         <Icon name='clock' />  {waitMin} - {waitMax} min
@@ -33,7 +33,7 @@ function WaitDetails(props) {
                         }}
                         style={{"fontSize":"12px"}}
                     >
-                        Cancel call back
+                        Cancel call
                     </Link>
                 </div>
                 <br/>


### PR DESCRIPTION
Fixes #90

Removed from "Request a call <back> from us" (home page).
Removed from "We'll call you <back> in 10-30 min".
Removed from "Cancel call <back>".

![2020-05-04 (3)](https://user-images.githubusercontent.com/2475430/81018618-be85fc80-8e19-11ea-8646-60b9224aa6c4.png)
![2020-05-04 (4)](https://user-images.githubusercontent.com/2475430/81018621-c04fc000-8e19-11ea-9aba-59ac26edfb38.png)
