### PR TITLE
Make logo small in left hand side besides on home page

### DIFF
--- a/callmeback/frontend/public/style.css
+++ b/callmeback/frontend/public/style.css
@@ -23,6 +23,6 @@ header {
 
 .corner-logo {
     padding-bottom: 1em;
-    padding-left: 2em;
+    padding-left: 1em;
     text-align: left;
 }

--- a/callmeback/frontend/public/style.css
+++ b/callmeback/frontend/public/style.css
@@ -12,7 +12,7 @@
 }
 
 .container-fluid {
-    margin-top: 10px;
+    margin-top: 15px;
 }
 
 header {
@@ -21,8 +21,8 @@ header {
     text-align: center;
 }
 
-cornerlogo {
+.corner-logo {
     padding-bottom: 1em;
-    padding-left: 1em;
+    padding-left: 2em;
     text-align: left;
 }

--- a/callmeback/frontend/public/style.css
+++ b/callmeback/frontend/public/style.css
@@ -12,7 +12,7 @@
 }
 
 .container-fluid {
-    margin-top: 15px;
+    margin-top: 1em;
 }
 
 header {

--- a/callmeback/frontend/public/style.css
+++ b/callmeback/frontend/public/style.css
@@ -11,8 +11,18 @@
     margin: (3, 0, 2);
 }
 
+.container-fluid {
+    margin-top: 10px;
+}
+
 header {
     padding-top: 2em;
     padding-bottom: 1em;
     text-align: center;
+}
+
+cornerlogo {
+    padding-bottom: 1em;
+    padding-left: 1em;
+    text-align: left;
 }

--- a/callmeback/frontend/src/Routes.jsx
+++ b/callmeback/frontend/src/Routes.jsx
@@ -11,7 +11,7 @@ function Routes() {
     return (
         <Router>
             <div className="container-fluid">
-                <Header />
+                <Header/>
                 <Switch>
                     <Route path='/home' component={Home} />
                     <Route path='/thankyou' component={ThankYou} />

--- a/callmeback/frontend/src/Routes.jsx
+++ b/callmeback/frontend/src/Routes.jsx
@@ -11,7 +11,7 @@ function Routes() {
     return (
         <Router>
             <div className="container-fluid">
-                <Header/>
+                <Header />
                 <Switch>
                     <Route path='/home' component={Home} />
                     <Route path='/thankyou' component={ThankYou} />

--- a/callmeback/frontend/src/components/Header.jsx
+++ b/callmeback/frontend/src/components/Header.jsx
@@ -3,7 +3,7 @@ import { useLocation } from "react-router";
 
 function Header() {
   let location = useLocation();
-  console.log(location)
+
   return (
     <div>
     {location.pathname==="/" || location.pathname==="/home" ?

--- a/callmeback/frontend/src/components/Header.jsx
+++ b/callmeback/frontend/src/components/Header.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
-function Header() {
+function Header(props) {
   return (
-    <header>
+    <cornerlogo>
       <img src="/nygov-logo.png" alt="New York State logo"/>
-    </header>
+    </cornerlogo>
   );
 }
 

--- a/callmeback/frontend/src/components/Header.jsx
+++ b/callmeback/frontend/src/components/Header.jsx
@@ -1,10 +1,19 @@
 import React from 'react'
+import { useLocation } from "react-router";
 
-function Header(props) {
+function Header() {
+  let location = useLocation();
+  console.log(location)
   return (
-    <cornerlogo>
-      <img src="/nygov-logo.png" alt="New York State logo"/>
-    </cornerlogo>
+    <div>
+    {location.pathname==="/" || location.pathname==="/home" ?
+      <header>
+        <img src="/nygov-logo.png" alt="New York State logo" width="30%" height="30%"/>
+      </header> :
+      <div className="corner-logo">
+        <img src="/nygov-logo.png" alt="New York State logo" width="25%" height="25%"/>
+      </div>}
+    </div>
   );
 }
 


### PR DESCRIPTION
Fixes #95 

Conditionally render the logo. Let me know if you think it should be smaller / bigger / further to left / right etc (the problem is that our margins aren't perfectly consistent across different pages and things so tried to pick something that looked reasonable everywhere..)

<img width="383" alt="Screen Shot 2020-05-05 at 1 18 23 PM" src="https://user-images.githubusercontent.com/29430896/81095969-c2765500-8ed3-11ea-85db-5377c18b556c.png">

<img width="364" alt="Screen Shot 2020-05-05 at 1 28 43 PM" src="https://user-images.githubusercontent.com/29430896/81096471-695af100-8ed4-11ea-9325-74027b0de78c.png">

<img width="364" alt="Screen Shot 2020-05-05 at 1 28 51 PM" src="https://user-images.githubusercontent.com/29430896/81096473-6b24b480-8ed4-11ea-9701-4b94f3626d5d.png">


- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
