### PR TITLE
Fix the size of the logo so that its not really stretched out in website (instead of mobile) view

### DIFF
--- a/callmeback/frontend/src/components/Header.jsx
+++ b/callmeback/frontend/src/components/Header.jsx
@@ -8,10 +8,10 @@ function Header() {
     <div>
     {location.pathname==="/" || location.pathname==="/home" ?
       <header>
-        <img src="/nygov-logo.png" alt="New York State logo" width="30%" height="30%"/>
+        <img src="/nygov-logo.png" alt="New York State logo" />
       </header> :
       <div className="corner-logo">
-        <img src="/nygov-logo.png" alt="New York State logo" width="25%" height="25%"/>
+        <img src="/nygov-logo.png" alt="New York State logo" style={{"width":"5em"}}/>
       </div>}
     </div>
   );


### PR DESCRIPTION
For some reason this didn't work when I tried to specify a class in style.css instead of putting it inline. Trying to get it in before the final release branch

<img width="979" alt="Screen Shot 2020-05-05 at 2 31 50 PM" src="https://user-images.githubusercontent.com/29430896/81102709-feaeb300-8edd-11ea-9405-f5672872d2bf.png">

<img width="373" alt="Screen Shot 2020-05-05 at 2 31 42 PM" src="https://user-images.githubusercontent.com/29430896/81102717-01110d00-8ede-11ea-84f1-69bcd2bde697.png">

<img width="786" alt="Screen Shot 2020-05-05 at 2 39 07 PM" src="https://user-images.githubusercontent.com/29430896/81102835-33226f00-8ede-11ea-904f-afdc335464b2.png">

instead of
<img width="809" alt="Screen Shot 2020-05-05 at 2 38 31 PM" src="https://user-images.githubusercontent.com/29430896/81102782-200f9f00-8ede-11ea-9ddf-b0530e0e5471.png">

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR