### PR TITLE
Abbreviate 'minutes' to 'min' in Moment.

### DIFF
--- a/callmeback/frontend/src/index.js
+++ b/callmeback/frontend/src/index.js
@@ -1,6 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Routes from './Routes.jsx';
+import moment from 'moment';
+
+moment.updateLocale("en", {
+  // Abbreviate relative time rendered output from "minutes" to "min"
+  relativeTime : {
+    m: '1 min',
+    mm: '%d min'
+  }
+});
 
 ReactDOM.render(
   <React.StrictMode>


### PR DESCRIPTION
Leverage `moment.updateLocale` to abbreviate 'minutes' to 'min' as rendered in WaitDetails.jsx. This change makes it possible to fit the estimated wait in one row of text in a mobile view. The configuration is placed in index.js since Moment requires this change to be global configuration, and the function does not need to be called with each render cycle.