### PR TITLE
Include junit-platform-launcher for VSCode testing

### DIFF
--- a/helloworld/build.gradle
+++ b/helloworld/build.gradle
@@ -25,7 +25,8 @@ dependencies {
   testImplementation('org.springframework.boot:spring-boot-starter-test') {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
-  testImplementation('org.junit.jupiter:junit-jupiter:5.4.0')
+  testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
+  testImplementation('org.junit.platform:junit-platform-launcher:1.5.2')
 }
 
 node {


### PR DESCRIPTION
once i made this change, i was able to run individual tests directly from VSCode (using the little "Run Test" button next to the test name, which is part of the vscode-java-test extension). also, i noted that log statements are being included in the Debug Console in VSCode.

suggestion from: microsoft/vscode-java-test#971

- [x] Tests pass
- [X] Appropriate changes to README are included in PR
- [X] Feature has been fleshed out in design document