### PR TITLE
Add simulated time field for reservation creation

### DIFF
--- a/callmeback/src/main/java/org/google/callmeback/api/Reservation.java
+++ b/callmeback/src/main/java/org/google/callmeback/api/Reservation.java
@@ -19,6 +19,13 @@ public class Reservation {
   /** The date/time when this reservation was modified. Auto-generated. */
   @LastModifiedDate public Date updatedDate;
 
+  /** The simulated date/time when this reservation was created.
+   ** Because the simulation can be sped up and run faster than wall clock time, the value
+   ** provided to represent the simulated time of the reservation may not be the same as the
+   ** wall clock time that the reservation is written to the database. 
+  */
+  public Date simulatedCreateDate;
+
   /** The telephone number where the resident would like to be called. */
   public String contactPhone;
 

--- a/callmeback/src/main/java/org/google/callmeback/api/Reservation.java
+++ b/callmeback/src/main/java/org/google/callmeback/api/Reservation.java
@@ -22,9 +22,9 @@ public class Reservation {
   /** The client-specified date/time when this reservation was created.
    ** For reservations created in real time through the app, this will be the same as the createdDate.
    ** Reservations can also be simulated to where their simulated create date may not be the same
-   ** as the wall clock time when the reservation is written to the database. 
+   ** as the wall clock time when the reservation is written to the database.
   */
-  public Date reservationCreateDate;
+  public Date reservationCreatedDate;
 
   /** The telephone number where the resident would like to be called. */
   public String contactPhone;

--- a/callmeback/src/main/java/org/google/callmeback/api/Reservation.java
+++ b/callmeback/src/main/java/org/google/callmeback/api/Reservation.java
@@ -19,12 +19,12 @@ public class Reservation {
   /** The date/time when this reservation was modified. Auto-generated. */
   @LastModifiedDate public Date updatedDate;
 
-  /** The simulated date/time when this reservation was created.
-   ** Because the simulation can be sped up and run faster than wall clock time, the value
-   ** provided to represent the simulated time of the reservation may not be the same as the
-   ** wall clock time that the reservation is written to the database. 
+  /** The client-specified date/time when this reservation was created.
+   ** For reservations created in real time through the app, this will be the same as the createdDate.
+   ** Reservations can also be simulated to where their simulated create date may not be the same
+   ** as the wall clock time when the reservation is written to the database. 
   */
-  public Date simulatedCreateDate;
+  public Date reservationCreateDate;
 
   /** The telephone number where the resident would like to be called. */
   public String contactPhone;

--- a/callmeback/src/main/java/org/google/callmeback/api/ReservationEvent.java
+++ b/callmeback/src/main/java/org/google/callmeback/api/ReservationEvent.java
@@ -1,13 +1,12 @@
 package org.google.callmeback.api;
 
-/** Represents a type of event in the reservation history. */
-public enum ReservationEvent {
-  /** Call was attempted but did not connect (busy, no answer, voicemail). */
-  ATTEMPTED,
-  /** Call connected and conversation started. */
-  CONNECTED,
-  /** Call was disrupted and conversation cut off (call failure, hangup). */
-  DISRUPTED,
-  /** Call was completed and conversation ended. */
-  COMPLETED
+import java.util.Date;
+
+/** Represents an event in the reservation history. */
+public class ReservationEvent {
+  /** The date/time when this event occurred. */
+  public Date date;
+
+  /** The event type. */
+  public ReservationEventType type;
 }

--- a/callmeback/src/main/java/org/google/callmeback/api/ReservationEventType.java
+++ b/callmeback/src/main/java/org/google/callmeback/api/ReservationEventType.java
@@ -1,0 +1,13 @@
+package org.google.callmeback.api;
+
+/** Represents a type of event in the reservation history. */
+public enum ReservationEventType {
+    /** Call was attempted but did not connect (busy, no answer, voicemail). */
+    ATTEMPTED,
+    /** Call connected and conversation started. */
+    CONNECTED,
+    /** Call was disrupted and conversation cut off (call failure, hangup). */
+    DISRUPTED,
+    /** Call was completed and conversation ended. */
+    COMPLETED
+}

--- a/simulation/producer/lib/simulation.js
+++ b/simulation/producer/lib/simulation.js
@@ -10,6 +10,7 @@ function sendReservation(apiUrl) {
         preferredName: faker.name.findName(),
         contactPhone: faker.phone.phoneNumber(),
         query: queries[Math.round(Math.random()*(queries.length-1))],
+        simulatedCreateDate: 
     };
     axios.post(apiUrl+'/api/v1/reservations', reservation)
         .then((response) => console.log(response))

--- a/simulation/producer/lib/simulation.js
+++ b/simulation/producer/lib/simulation.js
@@ -10,7 +10,6 @@ function sendReservation(apiUrl) {
         preferredName: faker.name.findName(),
         contactPhone: faker.phone.phoneNumber(),
         query: queries[Math.round(Math.random()*(queries.length-1))],
-        simulatedCreateDate: 
     };
     axios.post(apiUrl+'/api/v1/reservations', reservation)
         .then((response) => console.log(response))


### PR DESCRIPTION
Fixes #119 

Allow simulated time for a reservation creation to be added (as opposed to the time automatically populated by Mongo). Also make the "reservation event" contain a time as well as a type (will be necessary for calculations).

Checked that you can send this field to the API successfully.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [x] Feature has been fleshed out in design document