### PR TITLE
Add 2 Reservation Windows (from moving avg calc and naive calc) and display them on the FE

### DIFF
--- a/callmeback/backend/src/main/java/org/google/callmeback/api/CustomizedReservationRepository.java
+++ b/callmeback/backend/src/main/java/org/google/callmeback/api/CustomizedReservationRepository.java
@@ -72,7 +72,7 @@ class CustomizedReservationRepositoryImpl<T, ID> implements CustomizedReservatio
     long expectedWaitTimeMins = countReservations * AVERAGE_WAIT_TIME_MINS;
     Date currentDate = new Date();
     Instant currentDateInstant = currentDate.toInstant();
-    window.exp = Date.from(currentDateInstant.plus(Duration.ofMinutes(expectedWaitTimeMins)));
+    window.naiveExp = Date.from(currentDateInstant.plus(Duration.ofMinutes(expectedWaitTimeMins)));
 
     // Set window minimum as the greater value of expected time minus half of the hard-coded window
     // length and the current time. This ensures the current time is always within the window.
@@ -80,11 +80,11 @@ class CustomizedReservationRepositoryImpl<T, ID> implements CustomizedReservatio
         Date.from(
             currentDateInstant.plus(
                 Duration.ofMinutes(expectedWaitTimeMins - WINDOW_LENGTH_MINS / 2)));
-    window.min =
+    window.naiveMin =
         calculatedWindowMinimum.before(currentDate) ? currentDate : calculatedWindowMinimum;
 
     // Set window maximum as expected time plus half of the hard-coded window length
-    window.max =
+    window.naiveMax =
         Date.from(
             currentDateInstant.plus(
                 Duration.ofMinutes(expectedWaitTimeMins + (WINDOW_LENGTH_MINS / 2))));

--- a/callmeback/backend/src/main/java/org/google/callmeback/api/CustomizedReservationRepository.java
+++ b/callmeback/backend/src/main/java/org/google/callmeback/api/CustomizedReservationRepository.java
@@ -69,24 +69,24 @@ class CustomizedReservationRepositoryImpl<T, ID> implements CustomizedReservatio
     Optional<Long> averageWaitTimeMillis = getAverageWaitTimeMillis();
     long expectedWaitTimeMillis = 
         averageWaitTimeMillis.isPresent() ? averageWaitTimeMillis.get().longValue() : 0L;
-    window.exp = Date.from(requestDate.toInstant().plus(Duration.ofMillis(expectedWaitTimeMillis)));
+    window.naiveExp = Date.from(requestDate.toInstant().plus(Duration.ofMillis(expectedWaitTimeMillis)));
 
     // Set window minimum as the greater value of expected time minus half of the hard-coded window
-    // length and the current time. If it is set to the current time, update window.exp to the current
+    // length and the current time. If it is set to the current time, update window.naiveExp to the current
     // time as well. This ensures the window is either inclusive of or later than the current time
     // and that the expected time is not earlier than the current time.
     Date currentDate = new Date();
     Date calculatedWindowMinimum =
-        Date.from(window.exp.toInstant().minus(Duration.ofMillis(WINDOW_LENGTH_MILLIS / 2)));
+        Date.from(window.naiveExp.toInstant().minus(Duration.ofMillis(WINDOW_LENGTH_MILLIS / 2)));
     if (calculatedWindowMinimum.before(currentDate)) {
-      window.min = currentDate;
-      window.exp = currentDate;
+      window.naiveMin = currentDate;
+      window.naiveExp = currentDate;
     } else {
-      window.min = calculatedWindowMinimum;
+      window.naiveMin = calculatedWindowMinimum;
     }
 
     // Set window maximum as the window minimum plus the window length
-    window.max = Date.from(window.min.toInstant().plus(Duration.ofMillis(WINDOW_LENGTH_MILLIS)));
+    window.naiveMax = Date.from(window.naiveMin.toInstant().plus(Duration.ofMillis(WINDOW_LENGTH_MILLIS)));
     return window;
   }
 

--- a/callmeback/backend/src/main/java/org/google/callmeback/api/Reservation.java
+++ b/callmeback/backend/src/main/java/org/google/callmeback/api/Reservation.java
@@ -53,7 +53,7 @@ public class Reservation {
   /** The resident's feedback about the service experience. */
   public ReservationFeedback feedback;
 
-  /** The resident's feedback about the service experience. */
+  /** The expected call back times for the resident. */
   public ReservationWindow window;
 
   @Override

--- a/callmeback/backend/src/main/java/org/google/callmeback/api/ReservationWindow.java
+++ b/callmeback/backend/src/main/java/org/google/callmeback/api/ReservationWindow.java
@@ -3,7 +3,11 @@ package org.google.callmeback.api;
 import java.util.Date;
 
 public class ReservationWindow {
-  public Date min;
-  public Date max;
-  public Date exp;
+  public Date naiveMin;
+  public Date naiveMax;
+  public Date naiveExp;
+
+  public Date movingAvgMin;
+  public Date movingAvgMax;
+  public Date movingAvgExp;
 }

--- a/callmeback/backend/src/test/java/org/google/callmeback/api/ReservationRepositoryTest.java
+++ b/callmeback/backend/src/test/java/org/google/callmeback/api/ReservationRepositoryTest.java
@@ -111,16 +111,16 @@ public class ReservationRepositoryTest {
     Date requestedDate = new Date();
     Reservation reservation = createAndPersistReservation(requestedDate);
 
-    // There are no other reservations in the system, so the window.min should be equivalent to the
-    // window.exp
+    // There are no other reservations in the system, so the window.naiveMin should be equivalent to the
+    // window.naiveExp
     ReservationWindow window = reservation.window;
-    assertThat(window.exp).isEqualTo(window.min);
-    assertThat(window.max).isAfter(window.exp);
+    assertThat(window.naiveExp).isEqualTo(window.naiveMin);
+    assertThat(window.naiveMax).isAfter(window.naiveExp);
 
     Reservation reservationById = reservationRepository.findById(reservation.id).get();
     window = reservationById.window;
-    assertThat(window.exp).isEqualTo(window.min);
-    assertThat(window.max).isAfter(window.exp);
+    assertThat(window.naiveExp).isEqualTo(window.naiveMin);
+    assertThat(window.naiveMax).isAfter(window.naiveExp);
   }
 
   @Test
@@ -140,36 +140,36 @@ public class ReservationRepositoryTest {
     // Verify first reservation has same window minimum as expected callback, because there are no
     // reservations in the queue
     ReservationWindow window = olderReservationWithNoEvents.window;
-    assertThat(window.exp).isEqualTo(window.min);
-    assertThat(window.max).isAfter(window.exp);
+    assertThat(window.naiveExp).isEqualTo(window.naiveMin);
+    assertThat(window.naiveMax).isAfter(window.naiveExp);
     window = reservationRepository.findById(olderReservationWithNoEvents.id).get().window;
-    assertThat(window.exp).isEqualTo(window.min);
-    assertThat(window.max).isAfter(window.exp);
+    assertThat(window.naiveExp).isEqualTo(window.naiveMin);
+    assertThat(window.naiveMax).isAfter(window.naiveExp);
 
     // Verify reservation with one in the queue has the expected callback occur between the minimum
     // and maximum, because we're currently in the middle of the window
     window = reservationWithOneInQueue.window;
-    assertThat(window.exp).isAfter(window.min);
-    assertThat(window.max).isAfter(window.exp);
+    assertThat(window.naiveExp).isAfter(window.naiveMin);
+    assertThat(window.naiveMax).isAfter(window.naiveExp);
     window = reservationRepository.findById(reservationWithOneInQueue.id).get().window;
-    assertThat(window.exp).isAfter(window.min);
-    assertThat(window.max).isAfter(window.exp);
+    assertThat(window.naiveExp).isAfter(window.naiveMin);
+    assertThat(window.naiveMax).isAfter(window.naiveExp);
 
     // Verify reservation with two in the queue has the expected callback occur between the minimum
     // and maximum, because we're currently before the window
     window = reservationWithTwoInQueue.window;
-    assertThat(window.exp).isAfter(window.min);
-    assertThat(window.max).isAfter(window.exp);
+    assertThat(window.naiveExp).isAfter(window.naiveMin);
+    assertThat(window.naiveMax).isAfter(window.naiveExp);
     window = reservationRepository.findById(reservationWithTwoInQueue.id).get().window;
-    assertThat(window.exp).isAfter(window.min);
-    assertThat(window.max).isAfter(window.exp);
+    assertThat(window.naiveExp).isAfter(window.naiveMin);
+    assertThat(window.naiveMax).isAfter(window.naiveExp);
 
     // Verify that older reservation window occurs before the more recent reservations
     ReservationWindow olderWindow = olderReservationWithNoEvents.window;
     ReservationWindow newerWindow = reservationWithTwoInQueue.window;
-    assertThat(olderWindow.min).isBefore(newerWindow.min);
-    assertThat(olderWindow.exp).isBefore(newerWindow.exp);
-    assertThat(olderWindow.max).isBefore(newerWindow.max);
+    assertThat(olderWindow.naiveMin).isBefore(newerWindow.naiveMin);
+    assertThat(olderWindow.naiveExp).isBefore(newerWindow.naiveExp);
+    assertThat(olderWindow.naiveMax).isBefore(newerWindow.naiveMax);
   }
 
   private Reservation createAndPersistReservation(String topic) {

--- a/callmeback/backend/src/test/java/org/google/callmeback/api/ReservationRepositoryTest.java
+++ b/callmeback/backend/src/test/java/org/google/callmeback/api/ReservationRepositoryTest.java
@@ -137,10 +137,10 @@ public class ReservationRepositoryTest {
     Reservation res2WithNoEventsInSystem = createAndPersistReservation(date1);
   
     // Check that the reservations added so far have expected wait time of 0 (exp = min).
-    assertThat(res1WithNoEventsInSystem.window.exp).isEqualTo(res1WithNoEventsInSystem.window.min);
-    assertThat(res1WithNoEventsInSystem.window.max).isEqualTo(Date.from(res1WithNoEventsInSystem.window.min.toInstant().plus(Duration.ofMillis(600000))));
-    assertThat(res2WithNoEventsInSystem.window.exp).isEqualTo(res2WithNoEventsInSystem.window.min);
-    assertThat(res2WithNoEventsInSystem.window.max).isEqualTo(Date.from(res2WithNoEventsInSystem.window.min.toInstant().plus(Duration.ofMillis(600000))));
+    assertThat(res1WithNoEventsInSystem.window.naiveExp).isEqualTo(res1WithNoEventsInSystem.window.naiveMin);
+    assertThat(res1WithNoEventsInSystem.window.naiveMax).isEqualTo(Date.from(res1WithNoEventsInSystem.window.naiveMin.toInstant().plus(Duration.ofMillis(600000))));
+    assertThat(res2WithNoEventsInSystem.window.naiveExp).isEqualTo(res2WithNoEventsInSystem.window.naiveMin);
+    assertThat(res2WithNoEventsInSystem.window.naiveMax).isEqualTo(Date.from(res2WithNoEventsInSystem.window.naiveMin.toInstant().plus(Duration.ofMillis(600000))));
 
     // Reservation with multiple events and 10 minute wait time until first connect.
     Date date2 = new Date();
@@ -164,7 +164,7 @@ public class ReservationRepositoryTest {
     Date date3 = new Date();
     Reservation resWithOnePriorConnectedRes = createAndPersistReservation(date3);
     
-    assertThat(dateFormat.format(resWithOnePriorConnectedRes.window.exp))
+    assertThat(dateFormat.format(resWithOnePriorConnectedRes.window.naiveExp))
         .isEqualTo(dateFormat.format(Date.from(date3.toInstant().plus(Duration.ofMinutes(10)))));
 
     // Reservation with connected event and 20 minute wait time.
@@ -177,24 +177,24 @@ public class ReservationRepositoryTest {
     // New reservation should have expected wait time of 15 minutes.
     Date date5 = new Date();
     Reservation resWithMultiplePriorConnectedRes = createAndPersistReservation(date5);
-    assertThat(dateFormat.format(resWithMultiplePriorConnectedRes.window.exp))
+    assertThat(dateFormat.format(resWithMultiplePriorConnectedRes.window.naiveExp))
         .isEqualTo(dateFormat.format(Date.from(date5.toInstant().plus(Duration.ofMinutes(15)))));
-    assertThat(dateFormat.format(resWithMultiplePriorConnectedRes.window.min))
+    assertThat(dateFormat.format(resWithMultiplePriorConnectedRes.window.naiveMin))
         .isEqualTo(dateFormat.format(Date.from(date5.toInstant().plus(Duration.ofMinutes(15).minus(Duration.ofMillis(300000))))));
   
     // Old reservations should have updated wait times.
     Optional<Reservation> originalRes = reservationRepository.findById(res1WithNoEventsInSystem.id);
-    assertThat(dateFormat.format(originalRes.get().window.exp))
+    assertThat(dateFormat.format(originalRes.get().window.naiveExp))
         .isEqualTo(dateFormat.format(Date.from(date1.toInstant().plus(Duration.ofMinutes(15)))));
   
     // Minimum callback time is before the current time so exp and min time are set to current.
     Date date6 = Date.from(date1.toInstant().minus(Duration.ofMinutes(20)));
     Date timeCreatingRes = new Date();
     Reservation resWithWaitTimePassed = createAndPersistReservation(date6);
-    assertThat(resWithWaitTimePassed.window.exp).isEqualTo(resWithWaitTimePassed.window.min);
-    assertThat(resWithWaitTimePassed.window.exp).isAfter(dateFormat.format(Date.from(date6.toInstant().plus(Duration.ofMinutes(15)))));
-    assertThat(resWithWaitTimePassed.window.exp).isAfter(timeCreatingRes);
-    assertThat(resWithWaitTimePassed.window.exp).isBefore(new Date());
+    assertThat(resWithWaitTimePassed.window.naiveExp).isEqualTo(resWithWaitTimePassed.window.naiveMin);
+    assertThat(resWithWaitTimePassed.window.naiveExp).isAfter(dateFormat.format(Date.from(date6.toInstant().plus(Duration.ofMinutes(15)))));
+    assertThat(resWithWaitTimePassed.window.naiveExp).isAfter(timeCreatingRes);
+    assertThat(resWithWaitTimePassed.window.naiveExp).isBefore(new Date());
   }
 
   private Reservation createAndPersistReservation(String topic) {

--- a/callmeback/frontend/src/components/Reservation.jsx
+++ b/callmeback/frontend/src/components/Reservation.jsx
@@ -49,14 +49,17 @@ function Reservation(props) {
 }
 
 function convertReservationToState(reservation, id) {
-    const expCallStartMin = new Date(reservation.window.min)
-    const expCallStartMax = new Date(reservation.window.max)
+    const naiveExpCallStartMin = new Date(reservation.window.naiveMin)
+    const naiveExpCallStartMax = new Date(reservation.window.naiveMax)
+    const maExpCallStartMin = new Date(reservation.window.movingAvgMin)
+    const maExpCallStartMax = new Date(reservation.window.movingAvgMax)
 
     return {
         id: id,
         topic: "Business", // Not in response yet, hard coded for demo.
         resolved: reservation.resolution != null,
-        expCallStartMin, expCallStartMax,
+        naiveExpCallStartMin, naiveExpCallStartMax,
+        maExpCallStartMin, maExpCallStartMax,
     };
 };
 

--- a/callmeback/frontend/src/components/WaitDetails.jsx
+++ b/callmeback/frontend/src/components/WaitDetails.jsx
@@ -24,11 +24,20 @@ function WaitDetails(props) {
         waitTimeEstimate = <Moment format={'ddd, MMMM Do'}>{naiveExpCallStartMax}</Moment>;
     } else {
         waitTimeEstimate =
+            <div>
             <span>
                 <Moment fromNow ago>{naiveExpCallStartMin}</Moment>
                 {' '} - {' '}
                 <Moment fromNow ago>{naiveExpCallStartMax}</Moment>
             </span>
+            <br/>
+            {!!maExpCallStartMax &&
+            <span>
+                <Moment fromNow ago>{maExpCallStartMin}</Moment>
+                {' '} - {' '}
+                <Moment fromNow ago>{maExpCallStartMax}</Moment>
+            </span>}
+            </div>
     }
 
     return (

--- a/callmeback/frontend/src/components/WaitDetails.jsx
+++ b/callmeback/frontend/src/components/WaitDetails.jsx
@@ -6,35 +6,35 @@ import FaqAccordion from './FaqAccordion.jsx';
 import moment from 'moment';
 
 function WaitDetails(props) {
-    const {topic, expCallStartMin, expCallStartMax, id} = props.reservationDetails
+    const {topic, naiveExpCallStartMin, naiveExpCallStartMax, maExpCallStartMin, maExpCallStartMax, id} = props.reservationDetails
 
-    const callStartFormatted = <Moment format="h:mm A">{expCallStartMin}</Moment>
-    const callStartMaxFormatted = <Moment format="h:mm A">{expCallStartMax}</Moment>
+    const callStartFormatted = <Moment format="h:mm A">{naiveExpCallStartMin}</Moment>
+    const callStartMaxFormatted = <Moment format="h:mm A">{naiveExpCallStartMax}</Moment>
 
     const [checked, setCheckbox] = useState(false)
 
     const now = moment();
-    const callStartMaxMoment = moment(expCallStartMax);
+    const callStartMaxMoment = moment(naiveExpCallStartMax);
     const callStartMaxDuration = moment.duration(callStartMaxMoment.diff(now));
     const longWait = callStartMaxDuration.asHours() >= 24;
     const iconName = longWait ? 'calendar alternate outline' : 'clock';
 
     let waitTimeEstimate;
     if (longWait) {
-        waitTimeEstimate = <Moment format={'ddd, MMMM Do'}>{expCallStartMax}</Moment>;
+        waitTimeEstimate = <Moment format={'ddd, MMMM Do'}>{naiveExpCallStartMax}</Moment>;
     } else {
         waitTimeEstimate =
             <span>
-                <Moment fromNow ago>{expCallStartMin}</Moment>
+                <Moment fromNow ago>{naiveExpCallStartMin}</Moment>
                 {' '} - {' '}
-                <Moment fromNow ago>{expCallStartMax}</Moment>
+                <Moment fromNow ago>{naiveExpCallStartMax}</Moment>
             </span>
     }
 
     return (
         <Container text className='paper'>
             {/* Ensure props are loaded before rendering the component */}
-            {!!expCallStartMin &&
+            {!!naiveExpCallStartMin &&
             <div>
                 <div style={{"textAlign":"center"}} >
                     <div style={{"fontSize":"20px"}}>
@@ -48,8 +48,8 @@ function WaitDetails(props) {
                         to={{
                             pathname: "/cancel",
                             state: {
-                                expCallStartMin: expCallStartMin,
-                                expCallStartMax: expCallStartMax,
+                                naiveExpCallStartMin: naiveExpCallStartMin,
+                                naiveExpCallStartMax: naiveExpCallStartMax,
                                 id: id,
                             }
                         }}


### PR DESCRIPTION
Fixes #150 

Working on adding tests to cover WaitDetails in the FE but don't want to block this code from going in for that.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
- [ ] Feature has been fleshed out in design document