### PR TITLE
Make backend run tests only on explicit request

### DIFF
--- a/callmeback/backend/build.gradle
+++ b/callmeback/backend/build.gradle
@@ -29,5 +29,8 @@ dependencies {
 }
 
 test {
+  onlyIf {
+    gradle.getStartParameter().getTaskNames().contains("test")
+  }
 	useJUnitPlatform()
 }

--- a/callmeback/backend/build.gradle
+++ b/callmeback/backend/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'org.springframework.boot' version '2.2.6.RELEASE'
-	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
-	id 'java'
+  id 'org.springframework.boot' version '2.2.6.RELEASE'
+  id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+  id 'java'
 }
 
 group = 'org.google'
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 repositories {
-	mavenCentral()
+  mavenCentral()
 }
 
 dependencies {
@@ -32,5 +32,5 @@ test {
   onlyIf {
     gradle.getStartParameter().getTaskNames().contains("test")
   }
-	useJUnitPlatform()
+  useJUnitPlatform()
 }


### PR DESCRIPTION
Fixes #147: Tests will now only run if explicitly called with `./gradlew test`

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [x] Feature has been fleshed out in design document