### PR TITLE
Wait time update

### DIFF
--- a/callmeback/frontend/src/components/WaitDetails.test.js
+++ b/callmeback/frontend/src/components/WaitDetails.test.js
@@ -17,6 +17,9 @@ moment.updateLocale('en', {
     h: '1 hour',
   },
 });
+// Specify exact minutes in the 1-59 range. Without this, 45-59 mins is
+// rendered as "1 hour".
+moment.relativeTimeThreshold('m', 59);
 
 test('renders wait details with current time', async () => {
   const mockDate = new Date();
@@ -59,4 +62,27 @@ test('renders wait details with 1-2 hour wait', async () => {
   );
   expect(getAllByText('1 hour').length).toEqual(2);
   expect(getAllByText('2 hours').length).toEqual(2);
+});
+
+test('renders wait details with 45 mins - 1 hour', async () => {
+  const mockDateMin = new Date();
+  mockDateMin.setMinutes(mockDateMin.getMinutes() + 45);
+  // Add 30 mins to the starting wait time.
+  const mockDateMax = new Date(mockDateMin);
+  mockDateMax.setMinutes(mockDateMax.getMinutes() + 30);
+  const mockReservationDetails = {
+    topic: 'mocktopic',
+    naiveExpCallStartMin: mockDateMin,
+    naiveExpCallStartMax: mockDateMax,
+    maExpCallStartMin: mockDateMin,
+    maExpCallStartMax: mockDateMax,
+    id: 'mockid',
+  };
+  const { getAllByText } = render(
+    <Router>
+      <WaitDetails reservationDetails={mockReservationDetails} />
+    </Router>
+  );
+  expect(getAllByText('45 min').length).toEqual(2);
+  expect(getAllByText('1 hour').length).toEqual(2);
 });

--- a/callmeback/frontend/src/index.js
+++ b/callmeback/frontend/src/index.js
@@ -14,6 +14,9 @@ moment.updateLocale('en', {
     h: '1 hour',
   },
 });
+// Specify exact minutes in the 1-59 range. Without this, 45-59 mins is
+// rendered as "1 hour".
+moment.relativeTimeThreshold('m', 59);
 
 ReactDOM.render(
   <React.StrictMode>


### PR DESCRIPTION
Addresses part of #166 by allowing minutes in the 45-59 range to show specifically rather than round to "1 hour". This solves the "1 hour to 1 hour" case to start including minutes for the first number. However, it does not fix "1 hour 15 mins" showing up correctly (still rounds to "1 hour").

Adding test for this incremental fix.

Test still doesn't pull in changes directly from index.js file.